### PR TITLE
イケてない例

### DIFF
--- a/.github/workflows/bad_ci.yaml
+++ b/.github/workflows/bad_ci.yaml
@@ -1,0 +1,24 @@
+on:
+  pull_request:
+name: bad_ci
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - name: Run tests
+        run: make test
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - name: Lint
+        run: make lint


### PR DESCRIPTION
要するに↓の軸でcacheを使い分けたいのに、setup-goを使っているとこのあたりがいっしょくたにされて非効率だよ、という話。

- module cache vs build cache
- restore vs save
- job A vs job B（jobごとにcacheの内容が変わる）

あとは、default branchだけでcache saveするのがいいんじゃないかという話もある。